### PR TITLE
revert(deps): downgrade netty-codec-http2 from 4.1.61.Final to 4.1.59.Final in /connectors/sink-aws-s3

### DIFF
--- a/connectors/sink-aws-s3/pom.xml
+++ b/connectors/sink-aws-s3/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
-            <version>4.1.61.Final</version>
+            <version>4.1.59.Final</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>


### PR DESCRIPTION
Reverts linkall-labs/vance#45
4.1.61.Final has an connection issue, so let's reset the version to  4.1.59.Final for now